### PR TITLE
Use SDK for enrolling email OTP instead of prebuilt UI

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
   - AmplifyRTNCore (1.1.4):
     - React-Core
-  - Authsignal (1.0.5)
+  - Authsignal (1.0.14)
   - boost (1.76.0)
   - DoubleConversion (1.1.6)
   - FBLazyVector (0.72.1)
@@ -317,8 +317,8 @@ PODS:
   - React-jsinspector (0.72.1)
   - React-logger (0.72.1):
     - glog
-  - react-native-authsignal (1.0.3):
-    - Authsignal (= 1.0.5)
+  - react-native-authsignal (1.1.7):
+    - Authsignal (= 1.0.14)
     - React-Core
   - react-native-get-random-values (1.11.0):
     - React-Core
@@ -607,7 +607,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   AmplifyRTNCore: 43396d8b36c4969edd87d400b1142c52afbb294f
-  Authsignal: bdef4accd133e7db7eabc1106a5b044f6d017f04
+  Authsignal: 02c35064fb1a845bd20b26b1e017bbd9e00fd6ac
   boost: 57d2868c099736d80fcd648bf211b4431e51a558
   DoubleConversion: 5189b271737e1565bdce30deb4a08d647e3f5f54
   FBLazyVector: 55cd4593d570bd9e5e227488d637ce6a9581ce51
@@ -631,7 +631,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: 184eae1ecdedc7a083194bd9ff809c93f08fd34c
   React-jsinspector: d0b5bfd1085599265f4212034321e829bdf83cc0
   React-logger: b8103c9b04e707b50cdd2b1aeb382483900cbb37
-  react-native-authsignal: 95a0ab849c364674b8aee3010f1cf2252f8cbc46
+  react-native-authsignal: 8f33907331331cf5bd9097c82f96f65c7ec09e0c
   react-native-get-random-values: 21325b2244dfa6b58878f51f9aa42821e7ba3d06
   react-native-netinfo: 076df4f9b07f6670acf4ce9a75aac8d34c2e2ccc
   react-native-safe-area-context: 36cc67648134e89465663b8172336a19eeda493d

--- a/lambdas/create-auth-challenge.ts
+++ b/lambdas/create-auth-challenge.ts
@@ -21,20 +21,16 @@ export const handler: CreateAuthChallengeTriggerHandler = async event => {
     verificationMethod: VerificationMethod.PASSKEY,
   });
 
-  // Should match your URL Scheme if using the React Native SDK to launch the pre-built UI
-  const redirectUrl = 'authsignal://auth';
-
-  const {url, token} = await authsignal.track({
+  const {token} = await authsignal.track({
     userId,
     action: 'cognitoAuth',
     attributes: {
       email,
       challengeId,
-      redirectUrl,
     },
   });
 
-  event.response.publicChallengeParameters = {url, token};
+  event.response.publicChallengeParameters = {token};
 
   return event;
 };

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lint": "eslint .",
     "start": "react-native start",
     "test": "jest",
-    "deploy-lambdas": "serverless deploy"
+    "deploy-lambdas": "serverless deploy --region us-west-2"
   },
   "dependencies": {
     "@aws-amplify/react-native": "^1.1.4",
@@ -19,14 +19,14 @@
     "aws-amplify": "^6.4.3",
     "react": "18.2.0",
     "react-native": "0.72.1",
-    "react-native-authsignal": "^1.0.3",
+    "react-native-authsignal": "^1.1.7",
     "react-native-gesture-handler": "^2.12.0",
     "react-native-get-random-values": "^1.11.0",
     "react-native-safe-area-context": "^4.6.3",
     "react-native-screens": "^3.22.0"
   },
   "devDependencies": {
-    "@authsignal/node": "^2.0.0",
+    "@authsignal/node": "^2.3.1",
     "@babel/core": "^7.20.0",
     "@babel/preset-env": "^7.20.0",
     "@babel/runtime": "^7.20.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import {HomeScreen} from './HomeScreen';
 import {SignInScreen} from './SignInScreen';
 import {userPoolClientId, userPoolId} from './config';
 import {AuthContext} from './context';
+import {VerifyEmailScreen} from './VerifyEmailScreen';
 
 Amplify.configure({
   Auth: {
@@ -79,6 +80,14 @@ function App() {
                   component={SignInEmailScreen}
                   options={{
                     title: 'Sign in with email',
+                    headerBackTitleVisible: false,
+                  }}
+                />
+                <Stack.Screen
+                  name="VerifyEmail"
+                  component={VerifyEmailScreen}
+                  options={{
+                    title: 'Verify email',
                     headerBackTitleVisible: false,
                   }}
                 />

--- a/src/CreateAccountScreen.tsx
+++ b/src/CreateAccountScreen.tsx
@@ -1,20 +1,11 @@
-import {
-  confirmSignIn,
-  signIn,
-  SignInInput,
-  signUp,
-  SignUpInput,
-} from 'aws-amplify/auth';
+import {signIn, SignInInput, signUp, SignUpInput} from 'aws-amplify/auth';
 import React, {useState} from 'react';
 import {Alert, SafeAreaView, StyleSheet, TextInput} from 'react-native';
-import {launch} from 'react-native-authsignal';
 
 import {Button} from './Button';
-import {useAuthContext} from './context';
+import {authsignal} from './config';
 
-export function CreateAccountScreen() {
-  const {setIsSignedIn} = useAuthContext();
-
+export function CreateAccountScreen({navigation}: any) {
   const [email, setEmail] = useState('');
 
   return (
@@ -64,23 +55,12 @@ export function CreateAccountScreen() {
             return;
           }
 
-          const url = nextStep.additionalInfo!.url;
+          const token = nextStep.additionalInfo!.token;
+          const isEnrolled = nextStep.additionalInfo!.isEnrolled === 'true';
 
-          const token = await launch(url);
+          await authsignal.setToken(token);
 
-          if (!token) {
-            return;
-          }
-
-          const {isSignedIn} = await confirmSignIn({
-            challengeResponse: token,
-          });
-
-          if (!isSignedIn) {
-            return;
-          }
-
-          setIsSignedIn(true);
+          navigation.navigate('VerifyEmail', {email, isEnrolled});
         }}>
         Create account
       </Button>

--- a/src/HomeScreen.tsx
+++ b/src/HomeScreen.tsx
@@ -1,6 +1,6 @@
 import {signOut} from 'aws-amplify/auth';
 import React, {useEffect} from 'react';
-import {SafeAreaView, StyleSheet, Text, View} from 'react-native';
+import {Alert, SafeAreaView, StyleSheet, Text, View} from 'react-native';
 
 import {Button} from './Button';
 import {authsignal} from './config';
@@ -15,7 +15,15 @@ export function HomeScreen() {
       const isPasskeyAvailable = await authsignal.passkey.isAvailableOnDevice();
 
       if (!isPasskeyAvailable) {
-        authsignal.passkey.signUp();
+        try {
+          await authsignal.passkey.signUp();
+
+          Alert.alert('Passkey created.');
+        } catch (ex) {
+          if (ex instanceof Error) {
+            Alert.alert('Error: ', ex.message);
+          }
+        }
       }
     })();
   }, []);

--- a/src/SignInScreen.tsx
+++ b/src/SignInScreen.tsx
@@ -25,8 +25,8 @@ export function SignInScreen({navigation}: any) {
             });
 
             if (
-              errorCode === ErrorCode.passkeySignInCanceled ||
-              errorCode === ErrorCode.noPasskeyCredentialAvailable
+              errorCode === ErrorCode.user_canceled ||
+              errorCode === ErrorCode.no_credential
             ) {
               return navigation.navigate('SignInEmail');
             }

--- a/src/VerifyEmailScreen.tsx
+++ b/src/VerifyEmailScreen.tsx
@@ -1,0 +1,95 @@
+import {confirmSignIn} from 'aws-amplify/auth';
+import React, {useCallback, useEffect, useState} from 'react';
+import {
+  Alert,
+  SafeAreaView,
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableOpacity,
+} from 'react-native';
+
+import {Button} from './Button';
+import {authsignal} from './config';
+import {useAuthContext} from './context';
+
+export function VerifyEmailScreen({route}: any) {
+  const {setIsSignedIn} = useAuthContext();
+
+  const [code, setCode] = useState('');
+
+  const {email, isEnrolled} = route.params;
+
+  const sendEmail = useCallback(async () => {
+    if (isEnrolled) {
+      await authsignal.email.challenge();
+    } else {
+      await authsignal.email.enroll({email});
+    }
+  }, [email, isEnrolled]);
+
+  useEffect(() => {
+    sendEmail();
+  }, [sendEmail]);
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <TextInput
+        style={styles.input}
+        placeholder="Enter verification code"
+        onChangeText={setCode}
+        value={code}
+        autoFocus={true}
+        keyboardType={'number-pad'}
+      />
+      <Button
+        onPress={async () => {
+          const {data, error} = await authsignal.email.verify({code});
+
+          if (error || !data?.token) {
+            Alert.alert('Invalid code');
+          } else {
+            const {isSignedIn} = await confirmSignIn({
+              challengeResponse: data.token,
+            });
+
+            setIsSignedIn(isSignedIn);
+          }
+        }}>
+        Verify
+      </Button>
+      <TouchableOpacity
+        onPress={async () => {
+          setCode('');
+
+          await sendEmail();
+
+          Alert.alert('Verification code re-sent');
+        }}>
+        <Text style={styles.link}>Re-send code</Text>
+      </TouchableOpacity>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: '#F5FCFF',
+  },
+  input: {
+    alignSelf: 'stretch',
+    margin: 20,
+    height: 50,
+    borderColor: 'black',
+    borderRadius: 6,
+    borderWidth: 1,
+    padding: 10,
+  },
+  link: {
+    color: '#525EEA',
+    fontSize: 14,
+  },
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -15,12 +15,14 @@
     "@jridgewell/gen-mapping" "^0.3.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
-"@authsignal/node@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@authsignal/node/-/node-2.0.0.tgz#1a5a14b42f8dcb2e4d4842f840a318127ff83c98"
-  integrity sha512-naNBmozP9UoBdNWfJpirfdzNZ+y+qeGOp8kLtOEULHTuYE6pDF/Ugo7I4YGyOk4TPwybEX/vPOrF9zpGlCxD/Q==
+"@authsignal/node@^2.3.1":
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/@authsignal/node/-/node-2.3.1.tgz#9d25f52fbd087aea8db9fd36be8c52140dd0f7b8"
+  integrity sha512-+wal4volvexrMwwnLkTa/Zi+JOviBLHCQG+L4QnM/gS757ybhmxz97CWgD5Re3HXbtCSZ+k4Ghh/0N+Mk2Lcog==
   dependencies:
-    axios "^1.7.2"
+    axios "^1.7.9"
+    axios-retry "^4.5.0"
+    crypto "^1.0.1"
 
 "@aws-amplify/analytics@7.0.40":
   version "7.0.40"
@@ -3658,6 +3660,13 @@ axios-proxy-builder@^0.1.2:
   dependencies:
     tunnel "^0.0.6"
 
+axios-retry@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/axios-retry/-/axios-retry-4.5.0.tgz#441fdc32cedf63d6abd5de5d53db3667afd4c39b"
+  integrity sha512-aR99oXhpEDGo0UuAlYcn2iGRds30k366Zfa05XWScR9QaQD4JYiP3/1Qt1u7YlefUOK+cn0CcwoL1oefavQUlQ==
+  dependencies:
+    is-retry-allowed "^2.2.0"
+
 axios@^1.6.0:
   version "1.7.3"
   resolved "https://registry.yarnpkg.com/axios/-/axios-1.7.3.tgz#a1125f2faf702bc8e8f2104ec3a76fab40257d85"
@@ -3667,10 +3676,10 @@ axios@^1.6.0:
     form-data "^4.0.0"
     proxy-from-env "^1.1.0"
 
-axios@^1.7.2:
-  version "1.7.2"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.7.2.tgz#b625db8a7051fbea61c35a3cbb3a1daa7b9c7621"
-  integrity sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==
+axios@^1.7.9:
+  version "1.8.4"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.8.4.tgz#78990bb4bc63d2cae072952d374835950a82f447"
+  integrity sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==
   dependencies:
     follow-redirects "^1.15.6"
     form-data "^4.0.0"
@@ -4281,6 +4290,11 @@ cross-spawn@^7.0.0, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
     path-key "^3.1.0"
     shebang-command "^2.0.0"
     which "^2.0.1"
+
+crypto@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/crypto/-/crypto-1.0.1.tgz#2af1b7cad8175d24c8a1b0778255794a21803037"
+  integrity sha512-VxBKmeNcqQdiUQUW2Tzq0t377b54N2bMtXO/qiLa+6eRRmmC4qT3D4OnTGoT/U6O9aklQ/jTwbOtRMTTY8G0Ig==
 
 csstype@^3.0.2:
   version "3.1.2"
@@ -5572,6 +5586,11 @@ is-regex@^1.1.4:
   dependencies:
     call-bind "^1.0.2"
     has-tostringtag "^1.0.0"
+
+is-retry-allowed@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/is-retry-allowed/-/is-retry-allowed-2.2.0.tgz#88f34cbd236e043e71b6932d09b0c65fb7b4d71d"
+  integrity sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg==
 
 is-shared-array-buffer@^1.0.2:
   version "1.0.2"
@@ -7544,10 +7563,10 @@ react-is@^17.0.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
-react-native-authsignal@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/react-native-authsignal/-/react-native-authsignal-1.0.3.tgz#9d9cb791e8e9310afa78083a5042bcf156e6a4d1"
-  integrity sha512-oOk3x86hVDD58UZ/4ZR5BvxHK2INDv7992AJlsdtYZZxcAmCDcWs0LM0g7+EOK+l2Essz6mvge45rHdvjSjWvQ==
+react-native-authsignal@^1.1.7:
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/react-native-authsignal/-/react-native-authsignal-1.1.7.tgz#921c62f910e7fcf5f0b0ca5ea8e52c79075ea413"
+  integrity sha512-rb3z9LKw1AIKZVBAFAZydSgthdrxcrp4O1eN89Z6Hiyvus3XqQvuz+dMf29nMiKQtoSDrRqoMSIaJ4wzNDPphQ==
 
 react-native-gesture-handler@^2.12.0:
   version "2.12.0"


### PR DESCRIPTION
- Bump sdk versions
- Use Authsignal SDK to enroll email OTP with custom UI when creating account instead of prebuilt UI URL